### PR TITLE
Fixed issue #44.

### DIFF
--- a/src/main/java/com/keybox/manage/action/AuthKeysAction.java
+++ b/src/main/java/com/keybox/manage/action/AuthKeysAction.java
@@ -199,7 +199,16 @@ public class AuthKeysAction extends ActionSupport implements ServletRequestAware
 
 			Long userId = AuthUtil.getUserId(servletRequest.getSession());
 			
-			profileList = UserProfileDB.getProfilesByUser(userId);
+                        //Check if user is Full Access or not
+                        User user = UserDB.getUser(userId);
+                        if (user.getUserType().equals("M")) {
+                            profileList = ProfileDB.getAllProfiles();
+                            
+                        } else {
+                            profileList = UserProfileDB.getProfilesByUser(userId);
+                            
+                        }
+                        
 			sortedSet = PublicKeyDB.getPublicKeySet(sortedSet, userId);
 		}
 


### PR DESCRIPTION
It's now handled for Full Access accounts to not load Account specific profiles (because that's not possible) but make them load all profiles.
