### PR TITLE
Allow double-click selection of text rather than resizing the window

### DIFF
--- a/src/main/resources/KeyBoxConfig.properties
+++ b/src/main/resources/KeyBoxConfig.properties
@@ -30,4 +30,6 @@ forceUserKeyGeneration=true
 authKeysRefreshInterval=120
 #specify a external authentication module (ex: ldap-ol, ldap-ad).  Edit the jaas.conf to set connection details
 jaasModule=
+#set to false to prevent double clicking a terminal session from resizing it, too allow double-click selection of text
+doubleClickResize=true
 

--- a/src/main/webapp/admin/secure_shell.jsp
+++ b/src/main/webapp/admin/secure_shell.jsp
@@ -1,3 +1,4 @@
+<%@page import="com.keybox.common.util.AppConfig"%>
 <%
     /**
      * Copyright 2013 Sean Kavanagh - sean.p.kavanagh6@gmail.com
@@ -269,12 +270,18 @@
                 }
             } );
 
+<% // By default double clicking a window resets it to its default position.
+   // Provide an option to disable this behavior, as double clicking is a very
+   // common action to select words in a shell.
+   String doubleClickResize = AppConfig.getProperty("doubleClickResize");
+   if (doubleClickResize == null || doubleClickResize.length() == 0 || Boolean.valueOf(doubleClickResize)) { %>
              $(".run_cmd").dblclick(function (event, uii) {
                  var id = $(this).attr("id").replace("run_cmd_", "");
                  $(this).width("48%");
                  $(this).height(346+y_offset);
                  resize($(this));
              });
+<% } %>
 
 
             function resize(element) {


### PR DESCRIPTION
I regularly find myself double-clicking on words in the shell to select them for copy/paste as I do by habit in other shells, and hit a window resize instead.
This pull request contains a new property to disable the behavior, for your consideration.
Regards, Peter