### PR TITLE
Using e.ctrlKey inplace of keys[17].

### DIFF
--- a/src/main/webapp/admin/secure_shell.jsp
+++ b/src/main/webapp/admin/secure_shell.jsp
@@ -150,8 +150,8 @@
                     if (String.fromCharCode(keyCode) && String.fromCharCode(keyCode) != ''
                             && !keys[91] && !keys[93] && !keys[224] && !keys[27]
                             && !keys[37] && !keys[38] && !keys[39] && !keys[40]
-                            && !keys[13] && !keys[8] && !keys[9] && (!keys[17] 
-                            || keys[18]) && !keys[46] && !keys[45] && !keys[33] 
+                            && !keys[13] && !keys[8] && !keys[9] && (!e.ctrlKey 
+                            || e.altKey) && !keys[46] && !keys[45] && !keys[33] 
                             && !keys[34] && !keys[35] && !keys[36]) {
                         var cmdStr = String.fromCharCode(keyCode);
                         connection.send(JSON.stringify({id: getActiveTermsInstanceIds(), command: cmdStr}));
@@ -164,12 +164,7 @@
                 if (termFocus) {
                     var keyCode = (e.keyCode) ? e.keyCode : e.charCode;
                     keys[keyCode] = true;
-                    //prevent default for unix ctrl commands
-                    if (keys[17] && (keyCode == 83 || keyCode == 81 || keyCode == 84 || keyCode == 220 || keyCode == 90 || keyCode == 72 || keyCode == 87 || keyCode == 85 || keyCode == 82 || keyCode == 68)) {
-                        e.preventDefault();
-                        e.stopImmediatePropagation();
-                    }
-
+                    
                     //27 - ESC
                     //37 - LEFT
                     //38 - UP
@@ -185,9 +180,16 @@
                     //34 - PG DOWN
                     //35 - END
                     //36 - HOME
-                    if((keys[17] && !keys[18]) || keyCode == 27 || keyCode == 37 || keyCode == 38 || keyCode == 39 || keyCode == 40 || keyCode == 13 || keyCode == 8 || keyCode == 9 || keyCode == 46 || keyCode == 45 || keyCode == 33 || keyCode == 34 || keyCode == 35 || keyCode == 36) {
+                    if((e.ctrlKey && !e.altKey) || keyCode == 27 || keyCode == 37 || keyCode == 38 || keyCode == 39 || keyCode == 40 || keyCode == 13 || keyCode == 8 || keyCode == 9 || keyCode == 46 || keyCode == 45 || keyCode == 33 || keyCode == 34 || keyCode == 35 || keyCode == 36) {
                         connection.send(JSON.stringify({id: getActiveTermsInstanceIds(), keyCode: keyCode}));
                     }
+                    
+                    //prevent default for unix ctrl commands
+                    if (e.ctrlKey && (keyCode == 83 || keyCode == 81 || keyCode == 84 || keyCode == 220 || keyCode == 90 || keyCode == 72 || keyCode == 87 || keyCode == 85 || keyCode == 82 || keyCode == 68)) {
+                        e.preventDefault();
+                        e.stopImmediatePropagation();
+                    }
+
                 }
 
             });


### PR DESCRIPTION
Problem: Terminal become unresponsive when browser short-cuts are keyed in.

Ctrl + l clears terminal and moves focus to location bar in browser (firefox).
After keying this short-cut terminal will not show any output even if user presses any key till he/she press Ctrl key alone.
Similar behavior is observed with Ctrl + [b, B, o, j, A, s, S, f, k, K,  d, D, b, I, e, E , f4, n, P, tab, T, N, sht + del] etc.

Problem Analysis: When Ctrl is pressed in combination with other key(s) then key up event is fired for the key which is released first. For example if Ctrl + l is pressed and l is released first then key-up event will be fired for l key not for Ctrl key. So keys[17] will not be deleted and the next key-press is treated as pressed with Ctrl key(sends as "keyCode" not as "command). But when Ctrl is pressed alone and released, it deletes keys[17] and hence terminal works again.

Fix: Instead of relying on keys[17] for checking combination with Ctrl key we should use e.ctrlKey. Same can be done for alt key, keys[18] should be replaced with e.altKey where e is the event.