### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM maven:3
+
+ADD . /usr/src/app/
+WORKDIR /usr/src/app
+
+RUN mvn package jetty:effective-web-xml
+
+EXPOSE 8443
+
+CMD [ "mvn", "jetty:run" ]


### PR DESCRIPTION
Image builds successfully both locally and as an automated build at Docker Hub.
You can test using my account Automated Build: https://registry.hub.docker.com/u/pataquets/keybox/
How to test:
* Install Docker
* From the command line, run: ```$ docker run --rm -it -p 443:8443 pataquets/keybox```
* Browse to https://localhost