### PR TITLE
Fixed typographical error, changed adminstrative to administrative in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Steps:
 5. Users can login to create sessions on assigned systems
 6. Start a composite SSH session or create and execute a script across multiple sessions
 7. Add additional public keys to systems
-8. Disable any adminstrative public key forcing key rotation.
+8. Disable any administrative public key forcing key rotation.
 9. Audit session history
 
 Screenshots


### PR DESCRIPTION
@skavanagh, I've corrected a typographical error in the documentation of the [KeyBox](https://github.com/skavanagh/KeyBox) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.