### PR TITLE
Fix: Strings literals should be placed on the left side when checking…

### DIFF
--- a/src/main/java/com/keybox/manage/action/AuthKeysAction.java
+++ b/src/main/java/com/keybox/manage/action/AuthKeysAction.java
@@ -229,9 +229,9 @@ public class AuthKeysAction extends ActionSupport implements ServletRequestAware
 
 		//set key type
 		int type = KeyPair.RSA;
-		if(SSHUtil.KEY_TYPE.equals("dsa")) {
+		if("dsa".equals(SSHUtil.KEY_TYPE)) {
 			type = KeyPair.DSA;
-		} else if(SSHUtil.KEY_TYPE.equals("ecdsa")) {
+		} else if("ecdsa".equals(SSHUtil.KEY_TYPE)) {
 			type = KeyPair.ECDSA;
 		}
 

--- a/src/main/java/com/keybox/manage/util/SSHUtil.java
+++ b/src/main/java/com/keybox/manage/util/SSHUtil.java
@@ -168,9 +168,9 @@ public class SSHUtil {
 
 			//set key type
 			int type = KeyPair.RSA;
-			if(SSHUtil.KEY_TYPE.equals("dsa")) {
+			if("dsa".equals(SSHUtil.KEY_TYPE)) {
 				type = KeyPair.DSA;
-			} else if(SSHUtil.KEY_TYPE.equals("ecdsa")) {
+			} else if("ecdsa".equals(SSHUtil.KEY_TYPE)) {
 				type = KeyPair.ECDSA;
 			}
 			String comment = "keybox@global_key";


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1132- “Strings literals should be placed on the left side when checking for equality”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1132
 Please let me know if you have any questions.
Ayman Elkfrawy