### PR TITLE
Fix: The operator ("<>") should be used.

### DIFF
--- a/src/main/java/com/keybox/manage/action/OTPAction.java
+++ b/src/main/java/com/keybox/manage/action/OTPAction.java
@@ -106,7 +106,7 @@ public class OTPAction extends ActionSupport implements ServletRequestAware, Ser
 
             QRCodeWriter qrWriter = new QRCodeWriter();
 
-            Hashtable<EncodeHintType, String> hints = new Hashtable<EncodeHintType, String>();
+            Hashtable<EncodeHintType, String> hints = new Hashtable<>();
             hints.put(EncodeHintType.CHARACTER_SET, "UTF-8");
 
 

--- a/src/main/java/com/keybox/manage/action/SecureShellAction.java
+++ b/src/main/java/com/keybox/manage/action/SecureShellAction.java
@@ -53,11 +53,11 @@ public class SecureShellAction extends ActionSupport implements ServletRequestAw
     String password;
     String passphrase;
     Integer id;
-    List<HostSystem> systemList = new ArrayList<HostSystem>();
-    List<HostSystem> allocatedSystemList = new ArrayList<HostSystem>();
+    List<HostSystem> systemList = new ArrayList<>();
+    List<HostSystem> allocatedSystemList = new ArrayList<>();
     UserSettings userSettings;
 
-    static Map<Long, UserSchSessions> userSchSessionMap = new ConcurrentHashMap<Long, UserSchSessions>();
+    static Map<Long, UserSchSessions> userSchSessionMap = new ConcurrentHashMap<>();
 
 
     Script script = new Script();

--- a/src/main/java/com/keybox/manage/action/UploadAndPushAction.java
+++ b/src/main/java/com/keybox/manage/action/UploadAndPushAction.java
@@ -46,7 +46,7 @@ public class UploadAndPushAction extends ActionSupport implements ServletRequest
     File upload;
     String uploadContentType;
     String uploadFileName;
-    List<Long> idList = new ArrayList<Long>();
+    List<Long> idList = new ArrayList<>();
     String pushDir = "~";
     List<HostSystem> hostSystemList;
     HostSystem pendingSystemStatus;

--- a/src/main/java/com/keybox/manage/db/ProfileDB.java
+++ b/src/main/java/com/keybox/manage/db/ProfileDB.java
@@ -43,7 +43,7 @@ public class ProfileDB {
      */
     public static SortedSet getProfileSet(SortedSet sortedSet) {
 
-        ArrayList<Profile> profileList = new ArrayList<Profile>();
+        ArrayList<Profile> profileList = new ArrayList<>();
 
         String orderBy = "";
         if (sortedSet.getOrderByField() != null && !sortedSet.getOrderByField().trim().equals("")) {
@@ -85,7 +85,7 @@ public class ProfileDB {
      */
     public static List<Profile> getAllProfiles() {
 
-        ArrayList<Profile> profileList = new ArrayList<Profile>();
+        ArrayList<Profile> profileList = new ArrayList<>();
         Connection con = null;
         try {
             con = DBUtils.getConn();

--- a/src/main/java/com/keybox/manage/db/ProfileSystemsDB.java
+++ b/src/main/java/com/keybox/manage/db/ProfileSystemsDB.java
@@ -79,7 +79,7 @@ public class ProfileSystemsDB {
 	 */
 	public static List<HostSystem> getSystemsByProfile(Connection con, Long profileId) {
 
-		List<HostSystem> hostSystemList = new ArrayList<HostSystem>();
+		List<HostSystem> hostSystemList = new ArrayList<>();
 
 
 		try {
@@ -115,7 +115,7 @@ public class ProfileSystemsDB {
 	 */
 	public static List<HostSystem> getSystemsByProfile(Long profileId) {
 
-		List<HostSystem> hostSystemList = new ArrayList<HostSystem>();
+		List<HostSystem> hostSystemList = new ArrayList<>();
 
 		Connection con = null;
 
@@ -140,7 +140,7 @@ public class ProfileSystemsDB {
 	 */
 	public static List<Long> getSystemIdsByProfile(Connection con, Long profileId) {
 
-		List<Long> systemIdList = new ArrayList<Long>();
+		List<Long> systemIdList = new ArrayList<>();
 
 
 		try {
@@ -169,7 +169,7 @@ public class ProfileSystemsDB {
 	 */
 	public static List<Long> getSystemIdsByProfile(Long profileId) {
 
-		List<Long> systemIdList = new ArrayList<Long>();
+		List<Long> systemIdList = new ArrayList<>();
 
 		Connection con = null;
 
@@ -195,7 +195,7 @@ public class ProfileSystemsDB {
 	 */
 	public static List<Long> getSystemIdsByProfile(Connection con, Long profileId, Long userId) {
 
-		List<Long> systemIdList = new ArrayList<Long>();
+		List<Long> systemIdList = new ArrayList<>();
 
 
 		try {
@@ -226,7 +226,7 @@ public class ProfileSystemsDB {
 	 */
 	public static List<Long> getSystemIdsByProfile(Long profileId, Long userId) {
 
-		List<Long> systemIdList = new ArrayList<Long>();
+		List<Long> systemIdList = new ArrayList<>();
 
 		Connection con = null;
 

--- a/src/main/java/com/keybox/manage/db/PublicKeyDB.java
+++ b/src/main/java/com/keybox/manage/db/PublicKeyDB.java
@@ -176,7 +176,7 @@ public class PublicKeyDB {
      */
     public static SortedSet getPublicKeySet(SortedSet sortedSet) {
 
-        ArrayList<PublicKey> publicKeysList = new ArrayList<PublicKey>();
+        ArrayList<PublicKey> publicKeysList = new ArrayList<>();
 
 
         String orderBy = "";
@@ -243,7 +243,7 @@ public class PublicKeyDB {
      */
     public static SortedSet getPublicKeySet(SortedSet sortedSet, Long userId) {
 
-        ArrayList<PublicKey> publicKeysList = new ArrayList<PublicKey>();
+        ArrayList<PublicKey> publicKeysList = new ArrayList<>();
 
 
         String orderBy = "";
@@ -485,7 +485,7 @@ public class PublicKeyDB {
     public static List<String> getPublicKeysForSystem(Long systemId) {
 
         Connection con = null;
-        List<String> publicKeyList = new ArrayList<String>();
+        List<String> publicKeyList = new ArrayList<>();
         try {
             con = DBUtils.getConn();
 
@@ -502,7 +502,7 @@ public class PublicKeyDB {
     }
 
     public static List<String> getPublicKeysForSystem(Connection con, Long systemId) {
-        List<String> publicKeyList = new ArrayList<String>();
+        List<String> publicKeyList = new ArrayList<>();
 
         if(systemId==null){
             systemId=-99L;

--- a/src/main/java/com/keybox/manage/db/ScriptDB.java
+++ b/src/main/java/com/keybox/manage/db/ScriptDB.java
@@ -45,7 +45,7 @@ public class ScriptDB {
      */
     public static SortedSet getScriptSet(SortedSet sortedSet, Long userId) {
 
-        ArrayList<Script> scriptList = new ArrayList<Script>();
+        ArrayList<Script> scriptList = new ArrayList<>();
 
 
         String orderBy = "";

--- a/src/main/java/com/keybox/manage/db/SessionAuditDB.java
+++ b/src/main/java/com/keybox/manage/db/SessionAuditDB.java
@@ -94,7 +94,7 @@ public class SessionAuditDB {
     public static SortedSet getSessions(SortedSet sortedSet) {
         //get db connection
         Connection con = null;
-        List<SessionAudit> outputList = new LinkedList<SessionAudit>();
+        List<SessionAudit> outputList = new LinkedList<>();
 
         String orderBy = "";
         if (sortedSet.getOrderByField() != null && !sortedSet.getOrderByField().trim().equals("")) {
@@ -290,7 +290,7 @@ public class SessionAuditDB {
      */
     public static List<SessionOutput> getTerminalLogsForSession(Connection con, Long sessionId, Integer instanceId) {
 
-        List<SessionOutput> outputList = new LinkedList<SessionOutput>();
+        List<SessionOutput> outputList = new LinkedList<>();
         try {
             PreparedStatement stmt = con.prepareStatement("select * from terminal_log where instance_id=? and session_id=? order by log_tm asc");
             stmt.setLong(1, instanceId);
@@ -336,7 +336,7 @@ public class SessionAuditDB {
      */
     public static List<HostSystem> getHostSystemsForSession(Connection con, Long sessionId) {
 
-        List<HostSystem> hostSystemList = new ArrayList<HostSystem>();
+        List<HostSystem> hostSystemList = new ArrayList<>();
         try {
             PreparedStatement stmt = con.prepareStatement("select distinct instance_id, system_id from terminal_log where session_id=?");
             stmt.setLong(1, sessionId);

--- a/src/main/java/com/keybox/manage/db/SystemDB.java
+++ b/src/main/java/com/keybox/manage/db/SystemDB.java
@@ -52,7 +52,7 @@ public class SystemDB {
 	 * @return sortedSet with list of host systems
 	 */
 	public static SortedSet getUserSystemSet(SortedSet sortedSet, Long userId) {
-		List<HostSystem> hostSystemList = new ArrayList<HostSystem>();
+		List<HostSystem> hostSystemList = new ArrayList<>();
 
 		String orderBy = "";
 		if (sortedSet.getOrderByField() != null && !sortedSet.getOrderByField().trim().equals("")) {
@@ -109,7 +109,7 @@ public class SystemDB {
 	 * @return sortedSet with list of host systems
 	 */
 	public static SortedSet getSystemSet(SortedSet sortedSet) {
-		List<HostSystem> hostSystemList = new ArrayList<HostSystem>();
+		List<HostSystem> hostSystemList = new ArrayList<>();
 
 		String orderBy = "";
 		if (sortedSet.getOrderByField() != null && !sortedSet.getOrderByField().trim().equals("")) {
@@ -326,7 +326,7 @@ public class SystemDB {
 
 
 		Connection con = null;
-		List<HostSystem> hostSystemListReturn = new ArrayList<HostSystem>();
+		List<HostSystem> hostSystemListReturn = new ArrayList<>();
 
 		try {
 			con = DBUtils.getConn();
@@ -354,7 +354,7 @@ public class SystemDB {
 	 */
 	public static List<HostSystem> getAllSystems() {
 
-		List<HostSystem> hostSystemList = new ArrayList<HostSystem>();
+		List<HostSystem> hostSystemList = new ArrayList<>();
 
 		Connection con = null;
 
@@ -396,7 +396,7 @@ public class SystemDB {
 	 */
 	public static List<Long> getAllSystemIds(Connection con) {
 
-		List<Long> systemIdList = new ArrayList<Long>();
+		List<Long> systemIdList = new ArrayList<>();
 
 
 		try {
@@ -427,7 +427,7 @@ public class SystemDB {
 	 */
 	public static List<Long> getAllSystemIdsForUser(Connection con, Long userId) {
 
-		List<Long> systemIdList = new ArrayList<Long>();
+		List<Long> systemIdList = new ArrayList<>();
 
 
 		try {
@@ -457,7 +457,7 @@ public class SystemDB {
 	 */
 	public static List<Long> getAllSystemIdsForUser(Long userId) {
 		Connection con = null;
-		List<Long> systemIdList = new ArrayList<Long>();
+		List<Long> systemIdList = new ArrayList<>();
 		try {
 			con = DBUtils.getConn();
 			systemIdList = getAllSystemIdsForUser(con, userId);
@@ -476,7 +476,7 @@ public class SystemDB {
 	 */
 	public static List<Long> getAllSystemIds() {
 		Connection con = null;
-		List<Long> systemIdList = new ArrayList<Long>();
+		List<Long> systemIdList = new ArrayList<>();
 		try {
 			con = DBUtils.getConn();
 			systemIdList = getAllSystemIds(con);
@@ -499,7 +499,7 @@ public class SystemDB {
 	 */
 	public static List<Long> checkSystemPerms(Connection con, List<Long> systemSelectIdList, Long userId) {
 
-		List<Long> systemIdList = new ArrayList<Long>();
+		List<Long> systemIdList = new ArrayList<>();
 		List<Long> userSystemIdList = getAllSystemIdsForUser(con, userId);
 
 		for (Long systemId : userSystemIdList) {

--- a/src/main/java/com/keybox/manage/db/SystemStatusDB.java
+++ b/src/main/java/com/keybox/manage/db/SystemStatusDB.java
@@ -188,7 +188,7 @@ public class SystemStatusDB {
      */
     public static List<HostSystem> getAllSystemStatus(Long userId) {
 
-        List<HostSystem> hostSystemList = new ArrayList<HostSystem>();
+        List<HostSystem> hostSystemList = new ArrayList<>();
         Connection con = null;
         try {
             con = DBUtils.getConn();
@@ -210,7 +210,7 @@ public class SystemStatusDB {
      */
     private static List<HostSystem> getAllSystemStatus(Connection con, Long userId) {
 
-        List<HostSystem> hostSystemList = new ArrayList<HostSystem>();
+        List<HostSystem> hostSystemList = new ArrayList<>();
         try {
 
             PreparedStatement stmt = con.prepareStatement("select * from status where user_id=? order by id asc");

--- a/src/main/java/com/keybox/manage/db/UserDB.java
+++ b/src/main/java/com/keybox/manage/db/UserDB.java
@@ -51,7 +51,7 @@ public class UserDB {
      */
     public static SortedSet getUserSet(SortedSet sortedSet) {
 
-        ArrayList<User> userList = new ArrayList<User>();
+        ArrayList<User> userList = new ArrayList<>();
 
 
         String orderBy = "";
@@ -97,7 +97,7 @@ public class UserDB {
      */
     public static SortedSet getAdminUserSet(SortedSet sortedSet) {
 
-        ArrayList<User> userList = new ArrayList<User>();
+        ArrayList<User> userList = new ArrayList<>();
 
 
         String orderBy = "";

--- a/src/main/java/com/keybox/manage/db/UserProfileDB.java
+++ b/src/main/java/com/keybox/manage/db/UserProfileDB.java
@@ -79,7 +79,7 @@ public class UserProfileDB {
 
 
         Connection con = null;
-        List<Profile> profileList = new ArrayList<Profile>();
+        List<Profile> profileList = new ArrayList<>();
         try {
             con = DBUtils.getConn();
             profileList = getProfilesByUser(con, userId);
@@ -100,7 +100,7 @@ public class UserProfileDB {
      */
     public static List<Profile> getProfilesByUser(Connection con, Long userId) {
 
-        ArrayList<Profile> profileList = new ArrayList<Profile>();
+        ArrayList<Profile> profileList = new ArrayList<>();
 
 
         try {
@@ -134,7 +134,7 @@ public class UserProfileDB {
 
 
         Connection con = null;
-        List<User> userList = new ArrayList<User>();
+        List<User> userList = new ArrayList<>();
         try {
             con = DBUtils.getConn();
             userList = getUsersByProfile(con, profileId);
@@ -156,7 +156,7 @@ public class UserProfileDB {
      */
     public static List<User> getUsersByProfile(Connection con, Long profileId) {
 
-        ArrayList<User> userList = new ArrayList<User>();
+        ArrayList<User> userList = new ArrayList<>();
 
 
         try {

--- a/src/main/java/com/keybox/manage/model/UserSchSessions.java
+++ b/src/main/java/com/keybox/manage/model/UserSchSessions.java
@@ -21,7 +21,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class UserSchSessions {
 
-    Map<Integer, SchSession> schSessionMap = new ConcurrentHashMap<Integer, SchSession>();
+    Map<Integer, SchSession> schSessionMap = new ConcurrentHashMap<>();
 
 
     public Map<Integer, SchSession> getSchSessionMap() {

--- a/src/main/java/com/keybox/manage/model/UserSessionsOutput.java
+++ b/src/main/java/com/keybox/manage/model/UserSessionsOutput.java
@@ -21,7 +21,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class UserSessionsOutput {
 
     //instance id, host output
-    Map<Integer, SessionOutput> sessionOutputMap = new ConcurrentHashMap<Integer,SessionOutput>();
+    Map<Integer, SessionOutput> sessionOutputMap = new ConcurrentHashMap<>();
 
 
     public Map<Integer, SessionOutput> getSessionOutputMap() {

--- a/src/main/java/com/keybox/manage/socket/SecureShellWS.java
+++ b/src/main/java/com/keybox/manage/socket/SecureShellWS.java
@@ -161,7 +161,7 @@ public class SecureShellWS {
     /**
      * Maps key press events to the ascii values
      */
-    static Map<Integer, byte[]> keyMap = new HashMap<Integer, byte[]>();
+    static Map<Integer, byte[]> keyMap = new HashMap<>();
 
     static {
         //ESC

--- a/src/main/java/com/keybox/manage/util/SSHUtil.java
+++ b/src/main/java/com/keybox/manage/util/SSHUtil.java
@@ -114,7 +114,7 @@ public class SSHUtil {
 
 
 		//get passphrase cmd from properties file
-		Map<String, String> replaceMap = new HashMap<String, String>();
+		Map<String, String> replaceMap = new HashMap<>();
 		replaceMap.put("randomPassphrase", UUID.randomUUID().toString());
 
 		String passphrase = AppConfig.getProperty("defaultSSHPassphrase", replaceMap);

--- a/src/main/java/com/keybox/manage/util/SessionOutputUtil.java
+++ b/src/main/java/com/keybox/manage/util/SessionOutputUtil.java
@@ -38,7 +38,7 @@ public class SessionOutputUtil {
 
     private static Logger log = LoggerFactory.getLogger(SessionOutputUtil.class);
 
-    private static Map<Long, UserSessionsOutput> userSessionsOutputMap = new ConcurrentHashMap<Long, UserSessionsOutput>();
+    private static Map<Long, UserSessionsOutput> userSessionsOutputMap = new ConcurrentHashMap<>();
     public static boolean enableInternalAudit = "true".equals(AppConfig.getProperty("enableInternalAudit"));
     private static Gson gson = new GsonBuilder().registerTypeAdapter(AuditWrapper.class, new SessionOutputSerializer()).create();
     private static Logger systemAuditLogger = LoggerFactory.getLogger("com.keybox.manage.util.SystemAudit");
@@ -116,7 +116,7 @@ public class SessionOutputUtil {
      * @return session output list
      */
     public static List<SessionOutput> getOutput(Connection con, Long sessionId, User user) {
-        List<SessionOutput> outputList = new ArrayList<SessionOutput>();
+        List<SessionOutput> outputList = new ArrayList<>();
 
         UserSessionsOutput userSessionsOutput = userSessionsOutputMap.get(sessionId);
         if (userSessionsOutput != null) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S2293 - “The diamond operator ("<>") should be used ”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S2293
 Please let me know if you have any questions.
 Ayman Elkfrawy.