### PR TITLE
Fix: Utility classes should not have public constructors

### DIFF
--- a/src/main/java/com/keybox/common/util/AppConfig.java
+++ b/src/main/java/com/keybox/common/util/AppConfig.java
@@ -37,6 +37,9 @@ public class AppConfig {
         }
     }
 
+    private AppConfig() {
+    }
+
     /**
      * gets the property from config
      *

--- a/src/main/java/com/keybox/common/util/AuthUtil.java
+++ b/src/main/java/com/keybox/common/util/AuthUtil.java
@@ -27,6 +27,9 @@ import java.util.Calendar;
  */
 public class AuthUtil {
 
+    private AuthUtil() {
+    }
+
     /**
      * query session for OTP shared secret
      *

--- a/src/main/java/com/keybox/manage/db/AuthDB.java
+++ b/src/main/java/com/keybox/manage/db/AuthDB.java
@@ -36,6 +36,9 @@ public class AuthDB {
 
     private static Logger log = LoggerFactory.getLogger(AuthDB.class);
 
+    private AuthDB() {
+    }
+
     /**
      * auth user and return auth token if valid auth
      *

--- a/src/main/java/com/keybox/manage/db/PrivateKeyDB.java
+++ b/src/main/java/com/keybox/manage/db/PrivateKeyDB.java
@@ -32,6 +32,9 @@ public class PrivateKeyDB {
 
     private static Logger log = LoggerFactory.getLogger(PrivateKeyDB.class);
 
+    private PrivateKeyDB() {
+    }
+
     /**
      * returns public private key for application
      * @return app key values

--- a/src/main/java/com/keybox/manage/db/ProfileDB.java
+++ b/src/main/java/com/keybox/manage/db/ProfileDB.java
@@ -37,6 +37,9 @@ public class ProfileDB {
 
     public static final String SORT_BY_PROFILE_NM="nm";
 
+    private ProfileDB() {
+    }
+
     /**
      * method to do order by based on the sorted set object for profiles
      * @return list of profiles

--- a/src/main/java/com/keybox/manage/db/ProfileSystemsDB.java
+++ b/src/main/java/com/keybox/manage/db/ProfileSystemsDB.java
@@ -32,8 +32,11 @@ import org.slf4j.LoggerFactory;
 public class ProfileSystemsDB {
 
     private static Logger log = LoggerFactory.getLogger(ProfileSystemsDB.class);
-	
-	
+
+	private ProfileSystemsDB() {
+	}
+
+
 	/**
 	 * sets host systems for profile
 	 * 

--- a/src/main/java/com/keybox/manage/db/PublicKeyDB.java
+++ b/src/main/java/com/keybox/manage/db/PublicKeyDB.java
@@ -50,6 +50,9 @@ public class PublicKeyDB {
     public static final String SORT_BY_CREATE_DT= "create_dt";
     public static final String SORT_BY_USERNAME= "username";
 
+    private PublicKeyDB() {
+    }
+
     /**
      * Deletes all SSH keys for users that are not assigned in a profile
      *

--- a/src/main/java/com/keybox/manage/db/ScriptDB.java
+++ b/src/main/java/com/keybox/manage/db/ScriptDB.java
@@ -36,6 +36,9 @@ public class ScriptDB {
 
     public static final String SORT_BY_DISPLAY_NM="display_nm";
 
+    private ScriptDB() {
+    }
+
 
     /**
      * returns scripts based on sort order defined

--- a/src/main/java/com/keybox/manage/db/SessionAuditDB.java
+++ b/src/main/java/com/keybox/manage/db/SessionAuditDB.java
@@ -51,6 +51,9 @@ public class SessionAuditDB {
     public static final String SORT_BY_USERNAME = "username";
     public static final String SORT_BY_SESSION_TM = "session_tm";
 
+    private SessionAuditDB() {
+    }
+
 
     /**
      * deletes audit history for users if after time set in properties file

--- a/src/main/java/com/keybox/manage/db/SystemDB.java
+++ b/src/main/java/com/keybox/manage/db/SystemDB.java
@@ -43,6 +43,9 @@ public class SystemDB {
 	public static final String SORT_BY_HOST = "host";
 	public static final String SORT_BY_STATUS = "status_cd";
 
+	private SystemDB() {
+	}
+
 
 	/**
 	 * method to do order by based on the sorted set object for systems for user

--- a/src/main/java/com/keybox/manage/db/SystemStatusDB.java
+++ b/src/main/java/com/keybox/manage/db/SystemStatusDB.java
@@ -39,6 +39,9 @@ public class SystemStatusDB {
 
     private static Logger log = LoggerFactory.getLogger(SystemStatusDB.class);
 
+    private SystemStatusDB() {
+    }
+
 
     /**
      * set the initial status for selected systems

--- a/src/main/java/com/keybox/manage/db/UserDB.java
+++ b/src/main/java/com/keybox/manage/db/UserDB.java
@@ -44,6 +44,9 @@ public class UserDB {
     public static final String SORT_BY_USER_TYPE="user_type";
     public static final String SORT_BY_AUTH_TYPE="auth_type";
 
+    private UserDB() {
+    }
+
     /**
      * returns users based on sort order defined
      * @param sortedSet object that defines sort order

--- a/src/main/java/com/keybox/manage/db/UserProfileDB.java
+++ b/src/main/java/com/keybox/manage/db/UserProfileDB.java
@@ -34,6 +34,9 @@ public class UserProfileDB {
 
     private static Logger log = LoggerFactory.getLogger(UserProfileDB.class);
 
+    private UserProfileDB() {
+    }
+
     /**
      * sets users for profile
      * 

--- a/src/main/java/com/keybox/manage/db/UserThemeDB.java
+++ b/src/main/java/com/keybox/manage/db/UserThemeDB.java
@@ -32,6 +32,9 @@ public class UserThemeDB {
 
     private static Logger log = LoggerFactory.getLogger(UserThemeDB.class);
 
+    private UserThemeDB() {
+    }
+
     /**
      * get user theme
      *

--- a/src/main/java/com/keybox/manage/util/DBUtils.java
+++ b/src/main/java/com/keybox/manage/util/DBUtils.java
@@ -29,6 +29,9 @@ public class DBUtils {
 
     private static Logger log = LoggerFactory.getLogger(DBUtils.class);
 
+    private DBUtils() {
+    }
+
     /**
      * returns DB connection
      *

--- a/src/main/java/com/keybox/manage/util/DSPool.java
+++ b/src/main/java/com/keybox/manage/util/DSPool.java
@@ -38,6 +38,9 @@ public class DSPool {
     private static  int MIN_IDLE = Integer.parseInt(AppConfig.getProperty("minIdle"));
     private static int MAX_WAIT = Integer.parseInt(AppConfig.getProperty("maxWait"));
 
+    private DSPool() {
+    }
+
 
     /**
      * fetches the data source for H2 db

--- a/src/main/java/com/keybox/manage/util/EncryptionUtil.java
+++ b/src/main/java/com/keybox/manage/util/EncryptionUtil.java
@@ -35,6 +35,9 @@ public class EncryptionUtil {
     //secret key
     private static final byte[] key = new byte[]{'d', '3', '2', 't', 'p', 'd', 'M', 'o', 'I', '8', 'x', 'z', 'a', 'P', 'o', 'd'};
 
+    private EncryptionUtil() {
+    }
+
     /**
      * generate salt for hash
      *

--- a/src/main/java/com/keybox/manage/util/ExternalAuthUtil.java
+++ b/src/main/java/com/keybox/manage/util/ExternalAuthUtil.java
@@ -51,8 +51,10 @@ public class ExternalAuthUtil {
             System.setProperty("java.security.auth.login.config", ExternalAuthUtil.class.getClassLoader().getResource(".").getPath() + JAAS_CONF);
         }
     }
-    
-   
+
+    private ExternalAuthUtil() {
+    }
+
 
     /**
      * external auth login method

--- a/src/main/java/com/keybox/manage/util/OTPUtil.java
+++ b/src/main/java/com/keybox/manage/util/OTPUtil.java
@@ -47,6 +47,9 @@ public class OTPUtil {
     //interval for validation token change
     private static final int CHANGE_INTERVAL = 30;
 
+    private OTPUtil() {
+    }
+
 
     /**
      * generates OPT secret

--- a/src/main/java/com/keybox/manage/util/PasswordUtil.java
+++ b/src/main/java/com/keybox/manage/util/PasswordUtil.java
@@ -32,7 +32,10 @@ public class PasswordUtil {
 
         private static Pattern pattern = Pattern.compile(PASSWORD_REGEX);
 
-        /**
+    private PasswordUtil() {
+    }
+
+    /**
          * Validation to ensure strong password
          *
          * @param password password 

--- a/src/main/java/com/keybox/manage/util/SSHUtil.java
+++ b/src/main/java/com/keybox/manage/util/SSHUtil.java
@@ -57,6 +57,9 @@ public class SSHUtil {
 	public static final int SESSION_TIMEOUT = 60000;
 	public static final int CHANNEL_TIMEOUT = 60000;
 
+	private SSHUtil() {
+	}
+
 	/**
 	 * returns the system's public key
 	 *

--- a/src/main/java/com/keybox/manage/util/SessionOutputUtil.java
+++ b/src/main/java/com/keybox/manage/util/SessionOutputUtil.java
@@ -43,6 +43,9 @@ public class SessionOutputUtil {
     private static Gson gson = new GsonBuilder().registerTypeAdapter(AuditWrapper.class, new SessionOutputSerializer()).create();
     private static Logger systemAuditLogger = LoggerFactory.getLogger("com.keybox.manage.util.SystemAudit");
 
+    private SessionOutputUtil() {
+    }
+
     /**
      * removes session for user session
      *


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1118 - “Utility classes should not have public constructors ”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1118
 Please let me know if you have any questions.
 Ayman Elkfrawy.