### PR TITLE
Replace the usage of System.out or System.err by a logger

### DIFF
--- a/src/main/java/com/keybox/common/db/DBInitServlet.java
+++ b/src/main/java/com/keybox/common/db/DBInitServlet.java
@@ -106,7 +106,7 @@ public class DBInitServlet extends javax.servlet.http.HttpServlet {
 				DBUtils.closeStmt(pStmt);
 
 				//generate new key and insert passphrase
-				System.out.println("Setting KeyBox SSH public/private key pair");
+				log.info("Setting KeyBox SSH public/private key pair");
 
 				//generate application pub/pvt key and get values
 				String passphrase = SSHUtil.keyGen();
@@ -121,8 +121,8 @@ public class DBInitServlet extends javax.servlet.http.HttpServlet {
 				pStmt.execute();
 				DBUtils.closeStmt(pStmt);
 
-				System.out.println("KeyBox Generated Global Public Key:");
-				System.out.println(publicKey);
+				log.info("KeyBox Generated Global Public Key:");
+				log.info(publicKey);
 
 				passphrase = null;
 				publicKey = null;

--- a/src/main/java/com/keybox/manage/util/SSHUtil.java
+++ b/src/main/java/com/keybox/manage/util/SSHUtil.java
@@ -183,7 +183,7 @@ public class SSHUtil {
 
 				keyPair.writePrivateKey(PVT_KEY, passphrase.getBytes());
 				keyPair.writePublicKey(PUB_KEY, comment);
-                System.out.println("Finger print: " + keyPair.getFingerPrint());
+                log.info("Finger print: " + keyPair.getFingerPrint());
 				keyPair.dispose();
 			} catch (Exception e) {
 				log.error(e.toString(), e);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S106 - “Standard outputs should not be used directly to log anything”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S106
 Please let me know if you have any questions.
 Ayman Elkfrawy.