### PR TITLE
Fix: squid:S1643: Strings should not be concatenated using '+' in a loop

### DIFF
--- a/src/main/java/com/keybox/manage/db/SessionAuditDB.java
+++ b/src/main/java/com/keybox/manage/db/SessionAuditDB.java
@@ -301,11 +301,12 @@ public class SessionAuditDB {
             stmt.setLong(1, instanceId);
             stmt.setLong(2, sessionId);
             ResultSet rs = stmt.executeQuery();
-            String output = "";
+            StringBuilder outputBuilder = new StringBuilder("");
             while (rs.next()) {
-                output = output + rs.getString("output");
+                outputBuilder.append(rs.getString("output"));
             }
 
+            String output = outputBuilder.toString();
             output = output.replaceAll("\\u0007|\u001B\\[K|\\]0;|\\[\\d\\d;\\d\\dm|\\[\\dm","");
             while (output.contains("\b")) {
                 output = output.replaceFirst(".\b", "");

--- a/src/main/java/com/keybox/manage/util/SSHUtil.java
+++ b/src/main/java/com/keybox/manage/util/SSHUtil.java
@@ -348,34 +348,36 @@ public class SSHUtil {
 			channel.connect(CHANNEL_TIMEOUT);
 
 			String appPubKey = appPublicKey.replace("\n", "").trim();
-			String existingKeys="";
-			
+			StringBuilder existingKeysBuilder = new StringBuilder("");
+
 			String currentKey;
 			while ((currentKey = reader.readLine()) != null) {
-				existingKeys = existingKeys + currentKey +"\n";
+				existingKeysBuilder.append(currentKey).append("\n");
 			}
+			String existingKeys=existingKeysBuilder.toString();
 			existingKeys = existingKeys.replaceAll("\\n$","");
 			reader.close();
 			//disconnect
 			channel.disconnect();
 			
-			String newKeys="";
+			StringBuilder newKeysBuilder = new StringBuilder("");
 			if (keyManagementEnabled) {
 				//get keys assigned to system
 				List<String> assignedKeys = PublicKeyDB.getPublicKeysForSystem(hostSystem.getId());
 				for (String key: assignedKeys) {
-					newKeys = newKeys + key.replace("\n", "").trim() + "\n";
+					newKeysBuilder.append(key.replace("\n", "").trim()).append("\n");
 				}
-				newKeys = newKeys + appPubKey;
+				newKeysBuilder.append(appPubKey);
 			} else {
 				if (existingKeys.indexOf(appPubKey) < 0) {
-					newKeys = existingKeys + "\n" + appPubKey;
+					newKeysBuilder.append(existingKeys).append("\n").append(appPubKey);
 				}
 				else {
-					newKeys = existingKeys;
+					newKeysBuilder.append(existingKeys);
 				}
 			}
 
+			String newKeys=newKeysBuilder.toString();
 			if(!newKeys.equals(existingKeys)) {
 				log.info("Update Public Keys  ==> " + newKeys);
 				channel = session.openChannel("exec");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1132- “Strings should not be concatenated using '+' in a loop”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1643
 Please let me know if you have any questions.
Ayman Elkfrawy