### PR TITLE
Prevent users from deleting themselves

### DIFF
--- a/src/main/java/com/keybox/manage/action/UsersAction.java
+++ b/src/main/java/com/keybox/manage/action/UsersAction.java
@@ -96,7 +96,7 @@ public class UsersAction extends ActionSupport  implements ServletRequestAware {
     )
     public String deleteUser() {
 
-        if (user.getId() != null && user.getId()!=AuthUtil.getUserId(servletRequest.getSession())) {
+        if (user.getId() != null && !user.getId().equals(AuthUtil.getUserId(servletRequest.getSession()))) {
             UserDB.disableUser(user.getId());
             PublicKeyDB.deleteUserPublicKeys(user.getId());
             RefreshAuthKeyUtil.refreshAllSystems();


### PR DESCRIPTION
I changed the `deleteUser` method to avoid comparing by `Long` reference values. [Here](http://stackoverflow.com/a/8968390/1454261) is a nice StackOverflow answer about this, especially the part about autoboxed types implementing the flyweight pattern, but only for values -128 to 127.