### PR TITLE
Avoid file descriptor leak upon exception

### DIFF
--- a/src/main/java/com/keybox/manage/util/SSHUtil.java
+++ b/src/main/java/com/keybox/manage/util/SSHUtil.java
@@ -286,9 +286,7 @@ public class SSHUtil {
 		Channel channel = null;
 		ChannelSftp c = null;
 
-		try {
-
-
+		try (FileInputStream file = new FileInputStream(source)) {
 			channel = session.openChannel("sftp");
 			channel.setInputStream(System.in);
 			channel.setOutputStream(System.out);
@@ -297,11 +295,7 @@ public class SSHUtil {
 			c = (ChannelSftp) channel;
 			destination = destination.replaceAll("~\\/|~", "");
 
-
-			//get file input stream
-			FileInputStream file = new FileInputStream(source);
 			c.put(file, destination);
-			file.close();
 
 		} catch (Exception e) {
 			log.info(e.toString(), e);


### PR DESCRIPTION
Added [try-with-resources](https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html) statement to handle closing of the `FileInputStream`, including when an exception is thrown within the `try` block.