### PR TITLE
Avoid extra boxing for long primitive

### DIFF
--- a/src/main/java/com/keybox/manage/db/PublicKeyDB.java
+++ b/src/main/java/com/keybox/manage/db/PublicKeyDB.java
@@ -204,10 +204,10 @@ public class PublicKeyDB {
             int i=1;
             //set filters in prepared statement
             if(StringUtils.isNotEmpty(sortedSet.getFilterMap().get(FILTER_BY_USER_ID))){
-                stmt.setLong(i++, Long.valueOf(sortedSet.getFilterMap().get(FILTER_BY_USER_ID)));
+                stmt.setLong(i++, Long.parseLong(sortedSet.getFilterMap().get(FILTER_BY_USER_ID)));
             }
             if(StringUtils.isNotEmpty(sortedSet.getFilterMap().get(FILTER_BY_PROFILE_ID))){
-                stmt.setLong(i++, Long.valueOf(sortedSet.getFilterMap().get(FILTER_BY_PROFILE_ID)));
+                stmt.setLong(i++, Long.parseLong(sortedSet.getFilterMap().get(FILTER_BY_PROFILE_ID)));
             }
             if(StringUtils.isNotEmpty(sortedSet.getFilterMap().get(FILTER_BY_ENABLED))){
                 stmt.setBoolean(i, Boolean.valueOf(sortedSet.getFilterMap().get(FILTER_BY_ENABLED)));

--- a/src/main/java/com/keybox/manage/db/SessionAuditDB.java
+++ b/src/main/java/com/keybox/manage/db/SessionAuditDB.java
@@ -121,10 +121,10 @@ public class SessionAuditDB {
             int i=1;
             //set filters in prepared statement
             if(StringUtils.isNotEmpty(sortedSet.getFilterMap().get(FILTER_BY_USER_ID))){
-                stmt.setLong(i++, Long.valueOf(sortedSet.getFilterMap().get(FILTER_BY_USER_ID)));
+                stmt.setLong(i++, Long.parseLong(sortedSet.getFilterMap().get(FILTER_BY_USER_ID)));
             }
             if(StringUtils.isNotEmpty(sortedSet.getFilterMap().get(FILTER_BY_SYSTEM_ID))){
-                stmt.setLong(i, Long.valueOf(sortedSet.getFilterMap().get(FILTER_BY_SYSTEM_ID)));
+                stmt.setLong(i, Long.parseLong(sortedSet.getFilterMap().get(FILTER_BY_SYSTEM_ID)));
             }
 
             ResultSet rs = stmt.executeQuery();

--- a/src/main/java/com/keybox/manage/db/SystemDB.java
+++ b/src/main/java/com/keybox/manage/db/SystemDB.java
@@ -77,7 +77,7 @@ public class SystemDB {
 			stmt.setLong(1, userId);
 			//filter by profile id if exists
 			if (StringUtils.isNotEmpty(sortedSet.getFilterMap().get(FILTER_BY_PROFILE_ID))) {
-				stmt.setLong(2, Long.valueOf(sortedSet.getFilterMap().get(FILTER_BY_PROFILE_ID)));
+				stmt.setLong(2, Long.parseLong(sortedSet.getFilterMap().get(FILTER_BY_PROFILE_ID)));
 			}
 
 			ResultSet rs = stmt.executeQuery();
@@ -131,7 +131,7 @@ public class SystemDB {
 			con = DBUtils.getConn();
 			PreparedStatement stmt = con.prepareStatement(sql);
 			if (StringUtils.isNotEmpty(sortedSet.getFilterMap().get(FILTER_BY_PROFILE_ID))) {
-				stmt.setLong(1, Long.valueOf(sortedSet.getFilterMap().get(FILTER_BY_PROFILE_ID)));
+				stmt.setLong(1, Long.parseLong(sortedSet.getFilterMap().get(FILTER_BY_PROFILE_ID)));
 			}
 			ResultSet rs = stmt.executeQuery();
 


### PR DESCRIPTION
The code was creating a boxed primitive from `String` and then it was unboxing it since the methods expected `long` primitive as second argument. Using `Long.parseLong(java.lang.String)` method instead bypasses the unnecessary boxing, then unboxing operation.

Moreover, the [Long.valueOf(java.lang.String)](http://grepcode.com/file/repository.grepcode.com/java/root/jdk/openjdk/8u40-b25/java/lang/Long.java#Long.valueOf(java.lang.String)) implementation includes a call to `parseLong`.