### PR TITLE
Add a user type that prevents users from logging in

### DIFF
--- a/src/main/java/com/keybox/manage/action/LoginAction.java
+++ b/src/main/java/com/keybox/manage/action/LoginAction.java
@@ -99,11 +99,6 @@ public class LoginAction extends ActionSupport implements ServletRequestAware, S
             User user = AuthDB.getUserByAuthToken(authToken);
             if(user!=null) {
                 String sharedSecret = null;
-                if (User.PASSIVE.equals(user.getUserType())) {
-                    loginAuditLogger.info(auth.getUsername() + " (" + clientIP + ") - " + AUTH_ERROR_PASSIVE);
-                    addActionError(AUTH_ERROR_PASSIVE);
-                    return INPUT;
-                }
 
                 if (otpEnabled) {
                     sharedSecret = AuthDB.getSharedSecret(user.getId());
@@ -113,6 +108,13 @@ public class LoginAction extends ActionSupport implements ServletRequestAware, S
                         return INPUT;
                     }
                 }
+
+                if (User.PASSIVE.equals(user.getUserType())) {
+                    loginAuditLogger.info(auth.getUsername() + " (" + clientIP + ") - " + AUTH_ERROR_PASSIVE);
+                    addActionError(AUTH_ERROR_PASSIVE);
+                    return INPUT;
+                }
+
                 //check to see if admin has any assigned profiles
                 if(!User.MANAGER.equals(user.getUserType()) && (user.getProfileList()==null || user.getProfileList().size()<=0)){
                     loginAuditLogger.info(auth.getUsername() + " (" + clientIP + ") - " + AUTH_ERROR_NO_PROFILE);

--- a/src/main/java/com/keybox/manage/action/UsersAction.java
+++ b/src/main/java/com/keybox/manage/action/UsersAction.java
@@ -121,17 +121,21 @@ public class UsersAction extends ActionSupport  implements ServletRequestAware {
                 || user.getFirstNm().trim().equals("")) {
             addFieldError("user.firstNm", REQUIRED);
         }
-        
-        if (user != null && user.getPassword() != null && !user.getPassword().trim().equals("")){
-            
-            if(!user.getPassword().equals(user.getPasswordConfirm())) {
+
+        // Password validation is only for users who are permitted to log in (ie non-passive ones)
+        if (user != null && !User.PASSIVE.equals(user.getUserType())) {
+            if (user != null && user.getPassword() != null && !user.getPassword().trim().equals("")){
+
+                if(!user.getPassword().equals(user.getPasswordConfirm())) {
                     addActionError("Passwords do not match");
-            } else if(!PasswordUtil.isValid(user.getPassword())) {
+                } else if(!PasswordUtil.isValid(user.getPassword())) {
                     addActionError(PasswordUtil.PASSWORD_REQ_ERROR_MSG);
+                }
             }
-        }
-        if(user!=null && user.getId()==null && !Auth.AUTH_EXTERNAL.equals(user.getAuthType()) && (user.getPassword()==null || user.getPassword().trim().equals(""))){
-            addActionError("Password is required");
+
+            if(user!=null && user.getId()==null && !Auth.AUTH_EXTERNAL.equals(user.getAuthType()) && (user.getPassword()==null || user.getPassword().trim().equals(""))){
+                addActionError("Password is required");
+            }
         }
 
         if(user!=null && !UserDB.isUnique(user.getId(),user.getUsername())){

--- a/src/main/java/com/keybox/manage/action/UsersAction.java
+++ b/src/main/java/com/keybox/manage/action/UsersAction.java
@@ -124,7 +124,7 @@ public class UsersAction extends ActionSupport  implements ServletRequestAware {
 
         // Password validation is only for users who are permitted to log in (ie non-passive ones)
         if (user != null && !User.PASSIVE.equals(user.getUserType())) {
-            if (user != null && user.getPassword() != null && !user.getPassword().trim().equals("")){
+            if (user.getPassword() != null && !user.getPassword().trim().equals("")){
 
                 if(!user.getPassword().equals(user.getPasswordConfirm())) {
                     addActionError("Passwords do not match");

--- a/src/main/java/com/keybox/manage/model/Auth.java
+++ b/src/main/java/com/keybox/manage/model/Auth.java
@@ -23,7 +23,8 @@ public class Auth {
 
     public static final String ADMINISTRATOR="A";
     public static final String MANAGER="M";
-    
+    public static final String PASSIVE="P";
+
     public static final String AUTH_BASIC="BASIC";
     public static final String AUTH_EXTERNAL="EXTERNAL";
 

--- a/src/main/webapp/manage/view_users.jsp
+++ b/src/main/webapp/manage/view_users.jsp
@@ -53,16 +53,18 @@
             </s:if>
 
             $('.auth_type').change(function() {
-                hideShowPassword($(this).val());
+                showPassword($(this).val() != 'EXTERNAL');
             });
-            
+            $('.user_type').change(function() {
+                showPassword($(this).val() != 'P');
+            });
         });
         
         //hide show passwords
-        function hideShowPassword(val){
-            if(val=='EXTERNAL'){
+        function showPassword(show){
+            if(!show){
                 $('.password').closest('tr').hide();
-            }else {
+            } else {
                 $('.password').closest('tr').show();
             }
         }
@@ -77,7 +79,7 @@
                 <s:else>
                 $("#add_dialog").modal();
                 <s:if test="%{@com.keybox.manage.util.ExternalAuthUtil@externalAuthEnabled}">
-                    hideShowPassword($('.auth_type:checked').val());
+                    showPassword($('.auth_type:checked').val() != 'EXTERNAL');
                 </s:if>
                 </s:else>
             });
@@ -144,6 +146,9 @@
                          <s:if test="userType==\"A\"">
                             Administrative Only
                          </s:if>
+                         <s:elseif test="userType==\"P\"">
+                            Passive (cannot log in)
+                         </s:elseif>
                          <s:else>
                             Full Access
                          </s:else>
@@ -196,7 +201,7 @@
                             <s:form action="saveUser" class="save_user_form_add" autocomplete="off">
                                 <s:hidden name="_csrf" value="%{#session['_csrf']}"/>
                                 <s:textfield name="user.username" label="Username" size="15"/>
-                                <s:select name="user.userType" list="#{'A':'Administrative Only','M':'Full Access'}" label="UserType"/>
+                                <s:select name="user.userType" list="#{'A':'Administrative Only','M':'Full Access','P':'Passive (cannot log in)'}" label="UserType" cssClass="user_type"/>
                                 <s:if test="%{@com.keybox.manage.util.ExternalAuthUtil@externalAuthEnabled}">
                                     <s:radio name="user.authType" label="Authentication Type" list="#{'BASIC':'Basic', 'EXTERNAL':'External'}" cssClass="auth_type"/>
                                 </s:if>
@@ -234,7 +239,7 @@
                                     <s:form action="saveUser" id="save_user_form_edit_%{id}" autocomplete="off">
                                         <s:hidden name="_csrf" value="%{#session['_csrf']}"/>
                                         <s:textfield name="user.username" value="%{username}" label="Username" size="15"/>
-                                        <s:select name="user.userType" value="%{userType}" list="#{'A':'Administrative Only','M':'Full Access'}" label="UserType"/>
+                                        <s:select name="user.userType" value="%{userType}" list="#{'A':'Administrative Only','M':'Full Access','P':'Passive (cannot log in)'}" label="UserType" cssClass="user_type"/>
                                         <s:if test="%{@com.keybox.manage.util.ExternalAuthUtil@externalAuthEnabled}">
                                             <s:hidden name="user.authType" value="%{authType}"/>
                                             <tr>
@@ -253,8 +258,8 @@
                                         <s:textfield name="user.lastNm" value="%{lastNm}" label="Last Name" size="15"/>
                                         <s:textfield name="user.email" value="%{email}" label="Email Address" size="25"/>
                                         <s:if test="%{!@com.keybox.manage.util.ExternalAuthUtil@externalAuthEnabled || #user.authType==\"BASIC\"}">
-                                            <s:password name="user.password" value="" label="Password" size="15"/>
-                                            <s:password name="user.passwordConfirm" value="" label="Confirm Password" size="15"/>
+                                            <s:password name="user.password" value="" label="Password" size="15" cssClass="password"/>
+                                            <s:password name="user.passwordConfirm" value="" label="Confirm Password" size="15" cssClass="password"/>
                                         </s:if>
                                         <s:checkbox name="resetSharedSecret" label="Reset OTP Code"/>
                                         <s:hidden name="user.id" value="%{id}"/>


### PR DESCRIPTION
Use case is where you want to have users within the system, do not require them to be able to log into Keybox itself, but still require a method of storing their credentials for distribution to systems accordingly.

Arguably this could be also implemented via restricting access to Keybox itself and/or setting random passwords, but a specific user type felt cleaner/more self-contained :-)