### PR TITLE
update jetty ssl-config like

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ for Windows
 
         startKeyBox.bat
 
-How to Configure SSL in Jetty
+How to [Configure SSL in Jetty](http://www.eclipse.org/jetty/documentation/current/configuring-ssl.html)
 (it is a good idea to add or generate your own unique certificate)
 
-http://wiki.eclipse.org/Jetty/Howto/Configure_SSL
+http://www.eclipse.org/jetty/documentation/current/configuring-ssl.html
 
 To Build from Source
 ------


### PR DESCRIPTION
«Jetty 7 and Jetty 8 are now EOL (End of Life)
All development and stable releases are being performed with Jetty 9.
This wiki is now officially out of date and all content has been moved to the Jetty Documentation Hub
Direct Link to updated documentation: http://www.eclipse.org/jetty/documentation/current/configuring-ssl.html»