### PR TITLE
Potential fix for code scanning alert no. 4: Use of a broken or risky cryptographic algorithm

### DIFF
--- a/src/main/java/io/bastillion/manage/util/EncryptionUtil.java
+++ b/src/main/java/io/bastillion/manage/util/EncryptionUtil.java
@@ -233,27 +233,13 @@ public class EncryptionUtil {
 
         // Legacy CBC (v1) with serialized salt+iv+ciphertext under the classic headers.
         if (pem.contains(PEM_BEGIN_V1)) {
-            try {
-                String b64 = between(pem, PEM_BEGIN_V1, PEM_END_V1);
-                byte[] all = java.util.Base64.getMimeDecoder().decode(b64);
-                if (all.length < 16 + 16 + 16) throw new GeneralSecurityException("Invalid v1 envelope");
-
-                byte[] salt = new byte[16];
-                byte[] iv = new byte[16];
-                byte[] ct = new byte[all.length - 32];
-
-                System.arraycopy(all, 0, salt, 0, 16);
-                System.arraycopy(all, 16, iv, 0, 16);
-                System.arraycopy(all, 32, ct, 0, ct.length);
-
-                SecretKeySpec aesKey = deriveAesKey(passphrase, salt);
-                Cipher cipher = Cipher.getInstance(T_CBC);
-                cipher.init(Cipher.DECRYPT_MODE, aesKey, new IvParameterSpec(iv));
-                byte[] pt = cipher.doFinal(ct);
-                return new String(pt, StandardCharsets.UTF_8);
-            } catch (GeneralSecurityException e) {
-                throw new GeneralSecurityException("Failed to decrypt legacy CBC PEM", e);
-            }
+            // Deprecated: v1 pem envelopes used AES/CBC/PKCS5Padding, which is insecure.
+            // For security, legacy CBC-encrypted PEMs are no longer supported.
+            // Please migrate legacy PEM data to a supported format (e.g., using AES/GCM/NoPadding).
+            throw new GeneralSecurityException(
+                "Legacy PEM envelopes encrypted with AES/CBC/PKCS5Padding are no longer supported due to security risks. " +
+                "Please migrate data to a supported format (AES/GCM/NoPadding)."
+            );
         }
 
         throw new GeneralSecurityException("Unrecognized PEM envelope");


### PR DESCRIPTION
Potential fix for [https://github.com/bastillion-io/Bastillion/security/code-scanning/4](https://github.com/bastillion-io/Bastillion/security/code-scanning/4)

To address the insecure use of AES in CBC mode (`"AES/CBC/PKCS5Padding"`), the code should be migrated to use AES-GCM, which provides authenticated encryption and is the recommended standard. Specifically, the decryption of legacy PEM envelopes that used CBC mode should be rewritten to use GCM instead. Since legacy data might have been encrypted with CBC, a comprehensive fix involves converting legacy data when it is next read or providing a migration tool to re-encrypt it under GCM. The immediate code fix is to change the decryption logic to use `"AES/GCM/NoPadding"` throughout, with adjusted IV and authentication tag handling.

However, changing the algorithm directly may break decryption of existing data. The best approach is to refuse to accept CBC-encrypted data or to re-encrypt/decrypt using AES-GCM as soon as possible. The provided code should at least reject with a clear message if legacy CBC is encountered, guiding users to migrate.

**Specific changes:**
- In the block beginning at line 235, replace the code path that uses CBC-mode decryption with code that clearly and safely refuses to decrypt CBC-encrypted data. Optionally, provide a migration comment or stub—as replacing with GCM decryption would fail on old ciphertexts.
- Optionally, if all legacy data has been migrated, delete the CBC decryption branch entirely.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
