### PR TITLE
Fix for Exposing internal representation

### DIFF
--- a/src/main/java/io/bastillion/manage/model/UserSessionsOutput.java
+++ b/src/main/java/io/bastillion/manage/model/UserSessionsOutput.java
@@ -5,6 +5,7 @@
  */
 package io.bastillion.manage.model;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -15,11 +16,11 @@ public class UserSessionsOutput {
 
 
     public Map<Integer, SessionOutput> getSessionOutputMap() {
-        return sessionOutputMap;
+        return Collections.unmodifiableMap(new ConcurrentHashMap<>(sessionOutputMap));
     }
 
     public void setSessionOutputMap(Map<Integer, SessionOutput> sessionOutputMap) {
-        this.sessionOutputMap = sessionOutputMap;
+        this.sessionOutputMap = new ConcurrentHashMap<>(sessionOutputMap);
     }
 }
 


### PR DESCRIPTION
To fix this without changing core functionality, stop exposing internal mutable references:

- In `getSessionOutputMap()`, return an unmodifiable view of a defensive copy (`Collections.unmodifiableMap(new ConcurrentHashMap<>(sessionOutputMap))`), so callers can read data but cannot mutate internal state through the returned object.
- In `setSessionOutputMap(...)`, defensively copy input into a new `ConcurrentHashMap` instead of storing caller-provided reference.
- Add required import for `java.util.Collections`.

This should be done in `src/main/java/io/bastillion/manage/model/UserSessionsOutput.java` by editing the imports and the two accessor methods only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._