### PR TITLE
Potential fix for code scanning alert no. 20: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/src/main/java/io/bastillion/Main.java
+++ b/src/main/java/io/bastillion/Main.java
@@ -222,6 +222,7 @@ public class Main {
     private static void copyJarWebApp(URL webAppRoot, Path targetDir) throws IOException {
         JarURLConnection conn = (JarURLConnection) webAppRoot.openConnection();
         conn.setUseCaches(false);
+        Path normalizedTargetDir = targetDir.toAbsolutePath().normalize();
         try (JarFile jarFile = conn.getJarFile()) {
             Enumeration<JarEntry> entries = jarFile.entries();
             while (entries.hasMoreElements()) {
@@ -229,7 +230,11 @@ public class Main {
                 if (entry.isDirectory() || !entry.getName().startsWith("webapp/")) {
                     continue;
                 }
-                Path target = targetDir.resolve(entry.getName().substring("webapp/".length()));
+                String relativeName = entry.getName().substring("webapp/".length());
+                Path target = normalizedTargetDir.resolve(relativeName).normalize();
+                if (!target.startsWith(normalizedTargetDir)) {
+                    throw new IOException("Blocked suspicious jar entry path: " + entry.getName());
+                }
                 Files.createDirectories(target.getParent());
                 try (InputStream in = jarFile.getInputStream(entry)) {
                     Files.copy(in, target);


### PR DESCRIPTION
Potential fix for [https://github.com/bastillion-io/Bastillion/security/code-scanning/20](https://github.com/bastillion-io/Bastillion/security/code-scanning/20)

To fix Zip Slip safely, compute a normalized candidate path for each extracted entry and verify it remains under the intended destination directory before any filesystem operation.

Best fix for this code:
- In `src/main/java/io/bastillion/Main.java`, inside `copyJarWebApp(...)`, normalize `targetDir` once (absolute + normalized).
- For each entry, derive the relative path (`webapp/` prefix removed), resolve it against the normalized base, normalize again, and verify with `startsWith(baseDir)`.
- If validation fails, throw `IOException` (or skip and log; throwing is safer and explicit).
- Use the validated normalized path for both `createDirectories` and `copy`.

No new dependencies are required; existing `java.nio.file.Path` APIs are sufficient.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
