### PR TITLE
Potential fix for code scanning alert no. 19: Server-side template injection

### DIFF
--- a/src/main/java/loophole/mvc/base/TemplateServlet.java
+++ b/src/main/java/loophole/mvc/base/TemplateServlet.java
@@ -43,13 +43,32 @@ public class TemplateServlet extends HttpServlet {
         String uri = request.getRequestURI().replaceAll("\\" + TemplateServlet.VIEW_EXT + ".*", TemplateServlet.VIEW_EXT)
                 .replaceAll("^" + request.getContextPath(), "");
 
-        // reject path traversal attempts before resolving the view name to a template resource
-        if (URLDecoder.decode(uri, StandardCharsets.UTF_8).contains("..")) {
+        String templateName = toSafeTemplateName(uri);
+        if (templateName == null) {
             response.sendError(HttpServletResponse.SC_BAD_REQUEST);
             return;
         }
 
-        engine.process(uri, context, response.getWriter());
+        engine.process(templateName, context, response.getWriter());
+    }
+
+    private static String toSafeTemplateName(String rawUri) {
+        String decoded = URLDecoder.decode(rawUri, StandardCharsets.UTF_8);
+        if (!decoded.startsWith("/") || !decoded.endsWith(VIEW_EXT)) {
+            return null;
+        }
+
+        String[] segments = decoded.substring(1).split("/");
+        for (String segment : segments) {
+            if (segment.isEmpty() || ".".equals(segment) || "..".equals(segment)) {
+                return null;
+            }
+            if (!segment.matches("[A-Za-z0-9_-]+(\\.html)?")) {
+                return null;
+            }
+        }
+
+        return decoded;
     }
 
     @Override


### PR DESCRIPTION
Potential fix for [https://github.com/bastillion-io/Bastillion/security/code-scanning/19](https://github.com/bastillion-io/Bastillion/security/code-scanning/19)

Best-practice fix: ensure untrusted input cannot directly select arbitrary template names. Keep dynamic routing behavior, but strictly validate/canonicalize the derived template path before rendering.

Single best fix in this file:
1. After deriving `uri`, normalize it to a safe internal template path.
2. Enforce:
   - starts with `/`
   - ends with `.html`
   - only safe characters in path segments (`[A-Za-z0-9_-]`)
   - no empty segments, no `.`/`..`
3. If validation fails, return `400`.
4. Pass only the validated template path to `engine.process`.

This preserves functionality (URI-based view resolution) while removing attacker control over template-expression-capable names and blocking traversal/odd encodings more robustly than `contains("..")`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
