### PR TITLE
Fix for Exposing internal representation

### DIFF
--- a/src/main/java/io/bastillion/manage/model/UserSchSessions.java
+++ b/src/main/java/io/bastillion/manage/model/UserSchSessions.java
@@ -6,6 +6,7 @@
 package io.bastillion.manage.model;
 
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -15,11 +16,11 @@ public class UserSchSessions {
 
 
     public Map<Integer, SchSession> getSchSessionMap() {
-        return schSessionMap;
+        return Collections.unmodifiableMap(new ConcurrentHashMap<>(schSessionMap));
     }
 
     public void setSchSessionMap(Map<Integer, SchSession> schSessionMap) {
-        this.schSessionMap = schSessionMap;
+        this.schSessionMap = (schSessionMap == null) ? new ConcurrentHashMap<>() : new ConcurrentHashMap<>(schSessionMap);
     }
 
 }


### PR DESCRIPTION
Use defensive copying and read-only views to prevent exposing internal mutable state:

- In `getSchSessionMap()`, return an unmodifiable copy of the internal map instead of the map itself.
- In `setSchSessionMap(...)`, copy input data into a new `ConcurrentHashMap` instead of storing caller’s reference.
- Add `java.util.Collections` import for unmodifiable wrappers.

This keeps functionality (data can still be set/read) while preventing external code from mutating internal state via shared references.  
Edits are all in `src/main/java/io/bastillion/manage/model/UserSchSessions.java`, specifically imports and methods around lines 9–23.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._